### PR TITLE
Update file system id generation to expected regex

### DIFF
--- a/moto/fsx/models.py
+++ b/moto/fsx/models.py
@@ -1,4 +1,5 @@
 """FSxBackend class with methods for supported APIs."""
+import uuid
 
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
@@ -36,7 +37,7 @@ class FileSystem(BaseModel):
         ontap_configuration: Optional[Dict[str, Any]],
         open_zfs_configuration: Optional[Dict[str, Any]],
     ) -> None:
-        self.file_system_id = f"fs-moto{datetime.now().strftime('%Y%m%d%H%M%S')}"
+        self.file_system_id = f"fs-{uuid.uuid4().hex[:8]}"
         self.file_system_type = file_system_type
         if self.file_system_type not in FileSystemType.list_values():
             raise ValueError(f"Invalid FileSystemType: {self.file_system_type}")


### PR DESCRIPTION
This change intends to address https://github.com/getmoto/moto/issues/8148

Modifies how fsx fs id is generated so that:
* there are not collisions for requests that happen in parallel
* it complies with the expected regex.